### PR TITLE
Update global trends on data load

### DIFF
--- a/assets/js/core/app.js
+++ b/assets/js/core/app.js
@@ -220,6 +220,7 @@ export class App {
             // Загрузка глобальных данных
             if (this.modules.globalStats) {
                 await this.modules.globalStats.load();
+                await this.modules.globalStats.updateTrends();
             }
             
             // Загрузка рынков


### PR DESCRIPTION
### Motivation

- Ensure the trending coins list is refreshed whenever global statistics are loaded so UI shows up-to-date trends.
- Keep trends update coupled to the global stats load flow for consistent UX and timing.
- Only invoke the trends update when the `GlobalStats` module is available to avoid runtime errors.

### Description

- Added an explicit call to `await this.modules.globalStats.updateTrends()` immediately after `await this.modules.globalStats.load()` in `assets/js/core/app.js`.
- The call is guarded by the existing `if (this.modules.globalStats)` check so it runs only when the module is instantiated.
- No other logic or feature changes were made; the `updateTrends` implementation remains in `assets/js/features/global.js`.

### Testing

- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695eb73bc79c8330a3b411c901995cf7)