### PR TITLE
Fix data loading paths on GitHub Pages

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -10,7 +10,7 @@ document.addEventListener('DOMContentLoaded', () => {
 // Регистрация Service Worker
 if ('serviceWorker' in navigator) {
     window.addEventListener('load', () => {
-        navigator.serviceWorker.register('/service-worker.js')
+        navigator.serviceWorker.register(new URL('service-worker.js', window.location.href))
             .then(registration => {
                 console.log('Service Worker зарегистрирован:', registration);
                 

--- a/assets/js/core/config.js
+++ b/assets/js/core/config.js
@@ -2,9 +2,9 @@
 export class Config {
     constructor() {
         this.settings = {
-            DATA_PATH: '/data',
-            ASSETS_PATH: '/assets',
-            IMG_PATH: '/assets/img/coins',
+            DATA_PATH: 'data',
+            ASSETS_PATH: 'assets',
+            IMG_PATH: 'assets/img/coins',
             
             // Пагинация
             DEFAULT_PAGE_SIZE: 50,
@@ -25,16 +25,16 @@ export class Config {
             
             // Эндпоинты
             ENDPOINTS: {
-                GLOBAL: '/data/global.json',
-                FEARGREED: '/data/feargreed.json',
-                NEWS: '/data/news/latest.json',
-                TRENDING: '/data/trending.json',
-                COIN: (id) => `/data/coins/${id}.json`,
-                MARKET_PAGE: (page) => `/data/markets/page-${page}.json`,
-                MARKET_META: '/data/markets/meta.json',
-                TV_MAP: '/data/charts/tv-map.json',
-                GENERATED: '/data/generated.json',
-                SEARCH_INDEX: '/data/search-index.json'
+                GLOBAL: 'data/global.json',
+                FEARGREED: 'data/feargreed.json',
+                NEWS: 'data/news/latest.json',
+                TRENDING: 'data/trending.json',
+                COIN: (id) => `data/coins/${id}.json`,
+                MARKET_PAGE: (page) => `data/markets/page-${page}.json`,
+                MARKET_META: 'data/markets/meta.json',
+                TV_MAP: 'data/charts/tv-map.json',
+                GENERATED: 'data/generated.json',
+                SEARCH_INDEX: 'data/search-index.json'
             }
         };
         

--- a/assets/js/core/data-client.js
+++ b/assets/js/core/data-client.js
@@ -2,11 +2,16 @@
 export class DataClient {
     constructor() {
         this.cache = new Map();
+        this.baseUrl = new URL('.', window.location.href);
         this.config = {
             CACHE_TTL: 5 * 60 * 1000, // 5 минут
             RETRY_COUNT: 3,
             RETRY_DELAY: 1000
         };
+    }
+
+    resolveUrl(path) {
+        return new URL(path, this.baseUrl).toString();
     }
     
     async fetch(url, options = {}) {
@@ -74,43 +79,43 @@ export class DataClient {
     
     // Методы для получения конкретных данных
     async getGlobalData() {
-        return this.fetch('/data/global.json');
+        return this.fetch(this.resolveUrl('data/global.json'));
     }
     
     async getFearGreed() {
-        return this.fetch('/data/feargreed.json');
+        return this.fetch(this.resolveUrl('data/feargreed.json'));
     }
     
     async getNews() {
-        return this.fetch('/data/news/latest.json');
+        return this.fetch(this.resolveUrl('data/news/latest.json'));
     }
     
     async getTrending() {
-        return this.fetch('/data/trending.json');
+        return this.fetch(this.resolveUrl('data/trending.json'));
     }
     
     async getCoin(id) {
-        return this.fetch(`/data/coins/${id}.json`);
+        return this.fetch(this.resolveUrl(`data/coins/${id}.json`));
     }
     
     async getMarketsPage(page = 1) {
-        return this.fetch(`/data/markets/page-${page}.json`);
+        return this.fetch(this.resolveUrl(`data/markets/page-${page}.json`));
     }
     
     async getMarketsMeta() {
-        return this.fetch('/data/markets/meta.json');
+        return this.fetch(this.resolveUrl('data/markets/meta.json'));
     }
     
     async getTVMap() {
-        return this.fetch('/data/charts/tv-map.json');
+        return this.fetch(this.resolveUrl('data/charts/tv-map.json'));
     }
     
     async getGenerated() {
-        return this.fetch('/data/generated.json');
+        return this.fetch(this.resolveUrl('data/generated.json'));
     }
     
     async getSearchIndex() {
-        return this.fetch('/data/search-index.json');
+        return this.fetch(this.resolveUrl('data/search-index.json'));
     }
     
     // Пакетная загрузка

--- a/assets/js/core/format.js
+++ b/assets/js/core/format.js
@@ -175,7 +175,7 @@ export class Formatter {
     // URL иконки монеты
     coinIcon(id, symbol) {
         // Попытка загрузить локальную иконку
-        const localIcon = `/assets/img/coins/${id}.png`;
+        const localIcon = new URL(`assets/img/coins/${id}.png`, window.location.href).toString();
         
         // Fallback на генерацию иконки
         return localIcon;

--- a/assets/js/core/i18n.js
+++ b/assets/js/core/i18n.js
@@ -22,7 +22,7 @@ export class I18n {
     
     async loadTranslations(lang) {
         try {
-            const response = await fetch(`/assets/js/i18n/locales/${lang}.json`);
+            const response = await fetch(new URL(`assets/js/i18n/locales/${lang}.json`, window.location.href));
             this.translations[lang] = await response.json();
         } catch (error) {
             console.error(`Failed to load translations for ${lang}:`, error);


### PR DESCRIPTION
### Motivation
- Absolute `/data` and `/assets` URLs prevented loading JSON and images when the site is served from a subpath (e.g. GitHub Pages), causing the markets list to be empty.
- Resources and service worker registration need to be resolved relative to the current page URL to work on subpath deployments.

### Description
- Added `baseUrl` and `resolveUrl(path)` to `DataClient` and updated all `get*` methods to call `resolveUrl('data/...')` so data requests are resolved relative to `window.location.href`.
- Switched `Config` endpoints and path constants from leading-slash absolute paths (e.g. `'/data/...')` to relative paths (e.g. `'data/...'`).
- Updated `I18n.loadTranslations` and `Formatter.coinIcon` to use `new URL(..., window.location.href)` when fetching/localizing assets, and changed service worker registration to `navigator.serviceWorker.register(new URL('service-worker.js', window.location.href))`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695ebc3264f483309cf15a045d91832e)